### PR TITLE
Max player lobby adjustments

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -68,7 +68,7 @@ export abstract class DefaultServerConfig implements ServerConfig {
         GameMapType.Europe,
       ].includes(map)
     ) {
-      return Math.random() < 0.3 ? 150 : 70;
+      return Math.random() < 0.2 ? 150 : 70;
     }
     // Maps with ~2.5 - ~3.5 mil pixels
     if (
@@ -79,7 +79,7 @@ export abstract class DefaultServerConfig implements ServerConfig {
         GameMapType.Asia,
       ].includes(map)
     ) {
-      return Math.random() < 0.3 ? 100 : 50;
+      return Math.random() < 0.2 ? 100 : 50;
     }
     // Maps with ~2 mil pixels
     if (
@@ -90,7 +90,7 @@ export abstract class DefaultServerConfig implements ServerConfig {
         GameMapType.Japan, // Japan at this level because its 2/3 water
       ].includes(map)
     ) {
-      return Math.random() < 0.3 ? 70 : 40;
+      return Math.random() < 0.2 ? 70 : 40;
     }
     // Maps smaller than ~2 mil pixels
     if (
@@ -98,14 +98,10 @@ export abstract class DefaultServerConfig implements ServerConfig {
         map,
       )
     ) {
-      return Math.random() < 0.3 ? 60 : 35;
-    }
-    // world belongs with the ~2 mils, but these amounts never made sense so I assume the insanity is intended.
-    if (map == GameMapType.World) {
-      return Math.random() < 0.3 ? 150 : 60;
+      return Math.random() < 0.2 ? 60 : 35;
     }
     // default return for non specified map
-    return Math.random() < 0.3 ? 85 : 45;
+    return Math.random() < 0.2 ? 85 : 45;
   }
   workerIndex(gameID: GameID): number {
     return simpleHash(gameID) % this.numWorkers();

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -58,15 +58,54 @@ export abstract class DefaultServerConfig implements ServerConfig {
     return 60 * 1000;
   }
   lobbyMaxPlayers(map: GameMapType): number {
+    // Maps with ~4 mil pixels
+    if (
+      [
+        GameMapType.GatewayToTheAtlantic,
+        GameMapType.SouthAmerica,
+        GameMapType.NorthAmerica,
+        GameMapType.Africa,
+        GameMapType.Europe,
+      ].includes(map)
+    ) {
+      return Math.random() < 0.3 ? 150 : 70;
+    }
+    // Maps with ~2.5 - ~3.5 mil pixels
+    if (
+      [
+        GameMapType.Australia,
+        GameMapType.Iceland,
+        GameMapType.Britannia,
+        GameMapType.Asia,
+      ].includes(map)
+    ) {
+      return Math.random() < 0.3 ? 100 : 50;
+    }
+    // Maps with ~2 mil pixels
+    if (
+      [
+        GameMapType.Mena,
+        GameMapType.Mars,
+        GameMapType.Oceania,
+        GameMapType.Japan, // Japan at this level because its 2/3 water
+      ].includes(map)
+    ) {
+      return Math.random() < 0.3 ? 70 : 40;
+    }
+    // Maps smaller than ~2 mil pixels
+    if (
+      [GameMapType.TwoSeas, GameMapType.BlackSea, GameMapType.Pangaea].includes(
+        map,
+      )
+    ) {
+      return Math.random() < 0.3 ? 60 : 35;
+    }
+    // world belongs with the ~2 mils, but these amounts never made sense so I assume the insanity is intended.
     if (map == GameMapType.World) {
       return Math.random() < 0.3 ? 150 : 60;
     }
-    if (
-      [GameMapType.Mars, GameMapType.Africa, GameMapType.BlackSea].includes(map)
-    ) {
-      return Math.random() < 0.3 ? 70 : 50;
-    }
-    return Math.random() < 0.3 ? 60 : 40;
+    // default return for non specified map
+    return Math.random() < 0.3 ? 85 : 45;
   }
   workerIndex(gameID: GameID): number {
     return simpleHash(gameID) % this.numWorkers();


### PR DESCRIPTION
## Description:

Adjustments to lobbyMaxPlayer configuration function. Broke out tranches by map pixel count, commented to communicate to other collabs which tranch to place their map in. This change pairs well with the adjustment to lobby map selection to alternate between big and small maps. For the Potato (and mobile) players.


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

aPuddle
